### PR TITLE
Update ellipticcurve.php - include from same dir only

### DIFF
--- a/src/ellipticcurve.php
+++ b/src/ellipticcurve.php
@@ -1,9 +1,9 @@
 <?php
 
-require_once "utils/file.php";
-require_once "signature.php";
-require_once "publickey.php";
-require_once "privatekey.php";
-require_once "ecdsa.php";
+require_once __DIR__."/utils/file.php";
+require_once __DIR__."/signature.php";
+require_once __DIR__."/publickey.php";
+require_once __DIR__."/privatekey.php";
+require_once __DIR__."/ecdsa.php";
 
 ?>


### PR DESCRIPTION
I have a file called signature.php in my code and for some reason your code in trying to require_once file file instead of yours. this change seem to solve it.
it shouldn't break your code as much as I can see