### PR TITLE
Update `composer.json` with `ext-gmp` dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ To use the bindings, use Composer's autoload:
 require_once('vendor/autoload.php');
 ```
 
+#### External dependencies
+The package makes use of the 'GNU Multiple Precision' (GMP) library. For installation details, see: https://www.php.net/manual/en/gmp.installation.php
+
 ### Curves
 
 We currently support `secp256k1`, but you can add more curves to your project. You just need to use the `Curve::add()` method.

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         }
     ],
     "require": {
-        "php" : ">=7.0"
+        "php" : ">=7.0",
+        "ext-gmp": "*"
     },
     "autoload": {
         "files": ["src/ellipticcurve.php"],


### PR DESCRIPTION
# Description
In order to make use of the `gmp_*` functions, PHP needs to have GMP installed (not installed by default).

More information about GMP: https://www.php.net/manual/en/book.gmp.php

While installing the GMP library is not part of this package, it is a common use to add external dependencies to the composer.json as requirement.

Without the GMP extension, it cannot find the needed functions, resulting in fatal errors like:

```Call to undefined function EllipticCurve\Utils\gmp_init()```

(there is a opened issue at `starkbak/sdk-php` for it: https://github.com/starkbank/sdk-php/issues/66)

## Changes
- [x] Added `"ext-gmp": *` as requirement to `composer.json`
- [x] Updated README installation details with external dependency requirements