### PR TITLE
Fix #27: restore lazy autoload of curve.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Given a version number MAJOR.MINOR.PATCH, increment:
 
 
 ## [Unreleased]
+### Fixed
+- top-level gmp_init() running on every autoload, breaking transitive dependents without ext-gmp (#27)
 
 ## [2.2.0] - 2026-04-28
 ### Changed

--- a/src/ellipticcurve.php
+++ b/src/ellipticcurve.php
@@ -1,4 +1,1 @@
 <?php
-
-// Ensure curves are registered on load
-require_once(__DIR__ . "/curve.php");


### PR DESCRIPTION
## Summary
- 2.2.0 made `src/ellipticcurve.php` eagerly `require_once` `curve.php` on every `vendor/autoload.php`, which runs the top-level `new CurveFp(...)` instantiations and their inline `gmp_init` calls (curve params + GLV constants at `curve.php:24-27, 124-129`)
- Transitive dependents on hosts without `ext-gmp` (e.g. projects pulling `starkbank/ecdsa` via `sendgrid/sendgrid` and not using ECDSA) crash at autoload with `Call to undefined function EllipticCurve\gmp_init()`
- Reverting `ellipticcurve.php` to bare `<?php` restores the 2.1.0 behaviour: curves register lazily via the classmap the first time `CurveFp`/`Curve` is referenced

Fixes #27

## Test plan
- [x] `php -d disable_functions=gmp_init,gmp_add,…` + `require vendor/autoload.php` → no error
- [x] `CurveFp::getByOid([1,3,132,0,10])` returns `secp256k1`; both curves still register on first class reference
- [x] Full PHP test suite: 74/74 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)