### PR TITLE
Fix #23: restore PublicKey::fromString backwards compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Given a version number MAJOR.MINOR.PATCH, increment:
 
 
 ## [Unreleased]
+### Fixed
+- PublicKey::fromString rejecting base64 DER and PEM inputs, breaking sendgrid-php webhook verification (#23)
 
 ## [2.2.0] - 2026-04-28
 ### Changed

--- a/src/publickey.php
+++ b/src/publickey.php
@@ -92,6 +92,21 @@ class PublicKey
 
     static function fromString($string, $curve=null, $validatePoint=true)
     {
+        // Backwards compatibility with v0.0.5, where fromString accepted a
+        // base64-encoded DER (the format SendGrid's webhooks publish and
+        // sendgrid-php's EventWebhook still passes verbatim). Detect PEM
+        // and base64-DER inputs and route to the matching parser.
+        if (strpos($string, "-----BEGIN") !== false) {
+            return PublicKey::fromPem($string);
+        }
+        if (!ctype_xdigit($string)) {
+            $decoded = base64_decode($string, true);
+            if ($decoded === false) {
+                throw new Exception("Public key string is neither hex coordinates, base64 DER, nor PEM");
+            }
+            return PublicKey::fromDer($decoded);
+        }
+
         $curve = is_null($curve) ? CurveFp::$supportedCurves["secp256k1"] : $curve;
         $baseLength = gmp_intval(2 * $curve->length());
         if ((strlen($string) > 2 * $baseLength) and (substr($string, 0, 4) == "0004")) {

--- a/tests/testPublicKey.php
+++ b/tests/testPublicKey.php
@@ -42,6 +42,30 @@ class TestPublicKey extends TestCase
         \Test\assertTrue($publicKey1->point->y == $publicKey2->point->y, "y mismatch");
         \Test\assertTrue($publicKey1->curve->name == $publicKey2->curve->name, "curve mismatch");
     }
+
+    // v0.0.5 backwards compat: fromString used to accept a base64-encoded DER
+    // (the format sendgrid-php still passes when verifying webhooks). #23
+    public function testFromStringAcceptsBase64Der()
+    {
+        $privateKey = new \EllipticCurve\PrivateKey();
+        $publicKey1 = $privateKey->publicKey();
+        $base64Der = base64_encode($publicKey1->toDer());
+        $publicKey2 = \EllipticCurve\PublicKey::fromString($base64Der);
+        \Test\assertTrue($publicKey1->point->x == $publicKey2->point->x, "x mismatch");
+        \Test\assertTrue($publicKey1->point->y == $publicKey2->point->y, "y mismatch");
+        \Test\assertTrue($publicKey1->curve->name == $publicKey2->curve->name, "curve mismatch");
+    }
+
+    public function testFromStringAcceptsPem()
+    {
+        $privateKey = new \EllipticCurve\PrivateKey();
+        $publicKey1 = $privateKey->publicKey();
+        $pem = $publicKey1->toPem();
+        $publicKey2 = \EllipticCurve\PublicKey::fromString($pem);
+        \Test\assertTrue($publicKey1->point->x == $publicKey2->point->x, "x mismatch");
+        \Test\assertTrue($publicKey1->point->y == $publicKey2->point->y, "y mismatch");
+        \Test\assertTrue($publicKey1->curve->name == $publicKey2->curve->name, "curve mismatch");
+    }
 }
 
 


### PR DESCRIPTION
## Summary
- v0.0.5's `PublicKey::fromString($str)` accepted a **base64-encoded DER** — `return PublicKey::fromDer(base64_decode($str));`
- v2.0.0 silently swapped the contract to **hex-encoded coordinates** (`{x_hex}{y_hex}`, optionally `0004`-prefixed). Anything else trips `gmp_init(): Argument #1 ($num) is not an integer string`
- This broke `sendgrid-php`'s `EventWebhook::verifySignature`, which still calls `PublicKey::fromString($publicKey)` verbatim with the base64 DER SendGrid distributes — every consumer of SendGrid event webhooks is forced to pin `starkbank/ecdsa:0.0.5`
- Fix: `fromString` now detects the input shape and dispatches:
  - contains `-----BEGIN` → `fromPem`
  - contains a non-hex character → `fromDer(base64_decode(...))`
  - pure hex → existing v2 hex-coordinates path
- Disambiguation is safe in practice: hex-coord inputs are exactly 128 / 130 / 132 chars of `[0-9a-fA-F]`; base64 DER for an EC public key is ~88-120 chars and almost always contains `+`/`/`/`=` or non-hex letters

Fixes #23

## Test plan
- [x] `tests/testPublicKey.php::testFromStringAcceptsBase64Der` — reproduces sendgrid-php's call shape, round-trips a base64 DER through `fromString`
- [x] `tests/testPublicKey.php::testFromStringAcceptsPem` — full PEM input through `fromString`
- [x] Existing `testStringConversion` (hex coords path) still passes
- [x] Full suite: 76/76 passed (was 74; added 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)